### PR TITLE
feat(babel): allow preset to specify optimize deps

### DIFF
--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -177,6 +177,24 @@ defineRolldownBabelPreset({
 
 When running without Vite (pure Rolldown), `applyToEnvironmentHook` is ignored.
 
+### `optimizeDeps`
+
+A preset can declare dependencies that should be pre-bundled by Vite's dependency optimizer. The plugin automatically merges these into `optimizeDeps.include` in the Vite config.
+
+```js
+defineRolldownBabelPreset({
+  preset: ['@babel/preset-react'],
+  rolldown: {
+    filter: { id: /\.[jt]sx$/ },
+    optimizeDeps: {
+      include: ['react', 'react-dom'],
+    },
+  },
+})
+```
+
+When running without Vite (pure Rolldown), `optimizeDeps` is ignored.
+
 ### How preset filters work
 
 Preset filters operate at two levels:

--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, type HookFilter, type SourceMapInput } from 'rolldown'
 import {
+  collectOptimizeDepsInclude,
   createBabelOptionsConverter,
   filterPresetsWithConfigResolved,
   filterPresetsWithEnvironment,
@@ -19,6 +20,12 @@ async function babelPlugin(rawOptions: PluginOptions): Promise<Plugin> {
     name: '@rolldown/plugin-babel',
     // this plugin should run before TS, JSX, TSX transformations are done
     enforce: 'pre',
+    config() {
+      const include = collectOptimizeDepsInclude(rawOptions)
+      if (include.length > 0) {
+        return { optimizeDeps: { include } }
+      }
+    },
     configResolved(config: ResolvedConfig) {
       configFilteredOptions = filterPresetsWithConfigResolved(rawOptions, config)
       const resolved = resolveOptions(configFilteredOptions)

--- a/packages/babel/src/options.ts
+++ b/packages/babel/src/options.ts
@@ -147,6 +147,23 @@ export function filterPresetsWithConfigResolved(
   }
 }
 
+export function collectOptimizeDepsInclude(options: PluginOptions): string[] {
+  const result: string[] = []
+  for (const preset of options.presets ?? []) {
+    if (typeof preset === 'object' && 'rolldown' in preset) {
+      result.push(...(preset.rolldown.optimizeDeps?.include ?? []))
+    }
+  }
+  for (const override of options.overrides ?? []) {
+    for (const preset of override.presets ?? []) {
+      if (typeof preset === 'object' && 'rolldown' in preset) {
+        result.push(...(preset.rolldown.optimizeDeps?.include ?? []))
+      }
+    }
+  }
+  return result
+}
+
 /**
  * Pre-compile all preset filters and return a function that
  * converts options to babel options for a given context.

--- a/packages/babel/src/rolldownPreset.ts
+++ b/packages/babel/src/rolldownPreset.ts
@@ -14,6 +14,9 @@ export type RolldownBabelPreset = {
       moduleType?: ModuleTypeFilter
       code?: GeneralHookFilter
     }
+    optimizeDeps?: {
+      include?: string[]
+    }
     applyToEnvironmentHook?: (environment: PartialEnvironment) => boolean
     configResolvedHook?: (config: ResolvedConfig) => boolean
   }


### PR DESCRIPTION
Allow presets to specify optimize deps so that the user doesn't have to specify it when a preset injects some imports.