### PR TITLE
test(babel): externalize `react/jsx-runtime` to surpress warning

### DIFF
--- a/packages/babel/src/index.test.ts
+++ b/packages/babel/src/index.test.ts
@@ -752,6 +752,7 @@ async function buildWithVite(
 async function build(filename: string, code: string, options: PluginOptions): Promise<OutputChunk> {
   const bundle = await rolldown({
     input: filename,
+    external: [/^react\/jsx-runtime$/],
     plugins: [
       {
         name: 'virtual',


### PR DESCRIPTION
To surpress the following warning:
```
[UNRESOLVED_IMPORT] Warning: Could not resolve 'react/jsx-runtime' in foo.jsx?query
```