### PR TITLE
ci: use `pull_request_target` for pr labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,10 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  # SAFETY: pull_request_target is used here because:
+  # - The workflow does NOT check out PR code
+  # - Need access to github.token with write permissions to add labels
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
The access to github.token with write permissions is needed to add labels