### PR TITLE
fix(babel): exclude rolldown runtime module by default

### DIFF
--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -46,9 +46,9 @@ Note that this option receives [the syntax supported by babel](https://babeljs.i
 ### `exclude`
 
 - **Type:** `string | RegExp | (string | RegExp)[]`
-- **Default:** `/[\/\\]node_modules[\/\\]/`
+- **Default:** `/[\/\\]node_modules[\/\\]|\0rolldown\/runtime\.js/`
 
-Files matching the pattern will be skipped.
+Files matching the pattern will be skipped. The default also excludes Rolldown's runtime helper module (`\0rolldown/runtime.js`) so that Babel does not transform Rolldown's internal runtime code. If you override `exclude`, you are responsible for re-adding any of these entries you still want to skip.
 
 Note that this option receives [the syntax supported by babel](https://babeljs.io/docs/options#matchpattern) instead of picomatch.
 

--- a/packages/babel/src/index.test.ts
+++ b/packages/babel/src/index.test.ts
@@ -148,6 +148,49 @@ test('exclude allows transformation for non-matching files', async () => {
   expect(result.code).toContain('const result = true')
 })
 
+test('default exclude skips rolldown virtual runtime module', async () => {
+  const seenIds: string[] = []
+  const trackingPlugin: babel.PluginItem = (): babel.PluginObject => ({
+    visitor: {
+      Program(_p, state) {
+        seenIds.push(state.file.opts.filename ?? '<unknown>')
+      },
+    },
+  })
+
+  // A CJS dep forces rolldown to emit its `\0rolldown/runtime.js` helper
+  // region (for `__toESM` / `__commonJSMin`) into the chunk.
+  const files: Record<string, string> = {
+    'entry.js': `import dep from './dep.js'\nexport const result = dep.value`,
+    'dep.js': `module.exports = { value: 42 }`,
+  }
+  const bundle = await rolldown({
+    input: 'entry.js',
+    plugins: [
+      {
+        name: 'virtual',
+        resolveId(id) {
+          if (id in files) return id
+          if (id === './dep.js') return 'dep.js'
+        },
+        load(id) {
+          if (id in files) return files[id]
+        },
+      },
+      babelPlugin({ plugins: [trackingPlugin] }),
+    ],
+  })
+  const { output } = await bundle.generate()
+  const chunk = output.find((o) => o.type === 'chunk')
+  assert(chunk, 'expected a chunk in output')
+
+  // Sanity: rolldown must have actually emitted its runtime region, otherwise
+  // the assertion below would be vacuous.
+  expect(chunk.code).toContain('rolldown/runtime.js')
+
+  expect(seenIds).not.toContainEqual(expect.stringMatching(/rolldown[/\\]runtime\.js/))
+})
+
 test('include activates config only for matching files', async () => {
   const result = await build('foo.js', 'export const result = foo', {
     include: [/\.js$/],

--- a/packages/babel/src/options.ts
+++ b/packages/babel/src/options.ts
@@ -83,7 +83,8 @@ export type ResolvedPluginOptions = PluginOptions &
   Required<Pick<PluginOptions, 'include' | 'exclude' | 'sourceMap'>>
 
 export const DEFAULT_INCLUDE = [/\.(?:[jt]sx?|[cm][jt]s)(?:$|\?)/]
-export const DEFAULT_EXCLUDE = [/[/\\]node_modules[/\\]/]
+// oxlint-disable-next-line no-control-regex
+export const DEFAULT_EXCLUDE = [/[/\\]node_modules[/\\]|^\0rolldown\/runtime\.js$/]
 
 export function resolveOptions(options: PluginOptions): ResolvedPluginOptions {
   return {


### PR DESCRIPTION
closes https://github.com/rolldown/plugins/issues/53