### PR TITLE
chore: add shared Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:weekly", "group:allNonMajor"],
+  "extends": [
+    "github>Boshen/renovate",
+    "config:recommended",
+    "schedule:weekly",
+    "group:allNonMajor"
+  ],
   "labels": ["dependencies"],
   "ignorePaths": ["**/__tests__/**"],
   "rangeStrategy": "bump",
@@ -27,8 +32,5 @@
       ]
     }
   ],
-  "ignoreDeps": [
-    // manually bumping
-    "node"
-  ]
+  "ignoreDeps": ["node"]
 }


### PR DESCRIPTION
## Summary
- add or normalize `.github/renovate.json`
- make `github>Boshen/renovate` the first Renovate preset

## Verification
- parsed `.github/renovate.json` with `jq`
- verified `.extends[0] == "github>Boshen/renovate"`