### PR TITLE
chore: make renovate to pin all github actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,7 @@
     },
     {
       "matchDepTypes": ["action"],
-      "pinDigests": true,
-      "matchPackageNames": ["!actions/{/,}**", "!github/{/,}**"]
+      "pinDigests": true
     },
     {
       "groupName": "rolldown-related dependencies",


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing!
-->

Allows renovate to pin the hash instead.

See https://github.com/rolldown/plugins/pull/62#issuecomment-4402650591
