### PR TITLE
fix(emotion): build `oxc-unshadowed-visitor` before publish

### DIFF
--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -28,7 +28,7 @@
     "dev": "tsdown --watch",
     "build": "tsdown",
     "test": "vitest --project emotion",
-    "prepublishOnly": "pnpm run build"
+    "prepublishOnly": "pnpm run --filter @rolldown/plugin-emotion --filter oxc-unshadowed-visitor build"
   },
   "dependencies": {
     "@emotion/hash": "^0.9.2",


### PR DESCRIPTION
fixes #83

```
ℹ tsdown v0.22.0 powered by rolldown v1.0.0
ℹ config file: /home/runner/work/plugins/plugins/packages/emotion/tsdown.config.ts 
ℹ entry: ./src/index.ts
ℹ target: node22.12.0
ℹ tsconfig: ../../tsconfig.json
ℹ Build start
The `tsgo` option is experimental and may change in the future.
ℹ dist/index.mjs    25.46 kB │ gzip: 5.77 kB
ℹ dist/index.d.mts   2.46 kB │ gzip: 0.98 kB
ℹ 2 files, total: 27.92 kB
src/index.ts (4:30) [UNRESOLVED_IMPORT] Warning: Could not resolve 'oxc-unshadowed-visitor' in src/index.ts
   ╭─[ src/index.ts:4:31 ]
   │
 4 │ import { ScopedVisitor } from 'oxc-unshadowed-visitor'
   │                               ────────────┬───────────  
   │                                           ╰───────────── Module not found, treating it as an external dependency
───╯
```
https://github.com/rolldown/plugins/actions/runs/25659370514/job/75315713508#step:7:31
