### PR TITLE
fix(jsx-remove-attributes): handle query-suffixed module ids

### DIFF
--- a/packages/jsx-remove-attributes/src/index.ts
+++ b/packages/jsx-remove-attributes/src/index.ts
@@ -51,7 +51,8 @@ export default function jsxRemoveAttributesPlugin(
 
     transform: {
       filter: {
-        id: /\.[jt]sx$/,
+        // also match query-suffixed ids (e.g. Vite's `file.tsx?query`)
+        id: /\.[jt]sx(?:$|\?)/,
         ...(codeFilter && {
           code: {
             include: codeFilter,
@@ -60,14 +61,18 @@ export default function jsxRemoveAttributesPlugin(
       },
 
       handler: withMagicString(function (this, s, id, meta) {
-        const lang = id.endsWith('.tsx')
+        const [filepath] = id.split('?')
+        const lang = filepath.endsWith('.tsx')
           ? 'tsx'
-          : id.endsWith('.ts')
+          : filepath.endsWith('.ts')
             ? 'ts'
-            : id.endsWith('.jsx')
+            : filepath.endsWith('.jsx')
               ? 'jsx'
               : 'js'
-        const program = meta?.ast ?? this.parse(s.original, { lang })
+        // meta.ast is lazily parsed with the module type inferred from the raw id,
+        // which is wrong for query-suffixed ids — parse explicitly in that case
+        const program =
+          (filepath === id ? meta?.ast : undefined) ?? this.parse(s.original, { lang })
 
         new Visitor({
           JSXOpeningElement(node: ESTree.JSXOpeningElement) {

--- a/packages/jsx-remove-attributes/src/index.ts
+++ b/packages/jsx-remove-attributes/src/index.ts
@@ -51,7 +51,6 @@ export default function jsxRemoveAttributesPlugin(
 
     transform: {
       filter: {
-        // also match query-suffixed ids (e.g. Vite's `file.tsx?query`)
         id: /\.[jt]sx(?:$|\?)/,
         ...(codeFilter && {
           code: {
@@ -69,10 +68,7 @@ export default function jsxRemoveAttributesPlugin(
             : filepath.endsWith('.jsx')
               ? 'jsx'
               : 'js'
-        // meta.ast is lazily parsed with the module type inferred from the raw id,
-        // which is wrong for query-suffixed ids — parse explicitly in that case
-        const program =
-          (filepath === id ? meta?.ast : undefined) ?? this.parse(s.original, { lang })
+        const program = meta?.ast ?? this.parse(s.original, { lang })
 
         new Visitor({
           JSXOpeningElement(node: ESTree.JSXOpeningElement) {

--- a/packages/jsx-remove-attributes/tests/transform.test.ts
+++ b/packages/jsx-remove-attributes/tests/transform.test.ts
@@ -32,13 +32,21 @@ describe('fixtures', () => {
   }
 })
 
+describe('query-suffixed ids', () => {
+  it('removes attributes when the module id carries a query (e.g. Vite `file.tsx?query`)', async () => {
+    const code = 'export const App = () => <div data-testid="app">ok</div>\n'
+    const result = await transform(code, {}, 'virtual:entry.tsx?some-query=1')
+    expect(result).not.toContain('data-testid')
+  })
+})
+
 async function transform(
   code: string,
   options: JsxRemoveAttributesOptions,
   filename = 'virtual:entry.jsx',
 ): Promise<string> {
-  const ext = filename.match(/\.[jt]sx?$/)?.[0] ?? '.jsx'
-  const virtualEntry = `virtual:entry${ext}`
+  const ext = filename.match(/\.[jt]sx?(?=$|\?)/)?.[0] ?? '.jsx'
+  const virtualEntry = filename.includes('?') ? filename : `virtual:entry${ext}`
 
   const build = await rolldown({
     input: virtualEntry,
@@ -50,7 +58,11 @@ async function transform(
           return { id, external: true }
         },
         load(id) {
-          if (id === virtualEntry) return code
+          if (id === virtualEntry) {
+            // query-suffixed ids defeat rolldown's extension-based module type
+            // inference, so set it explicitly (as Vite does in real pipelines)
+            return virtualEntry.includes('?') ? { code, moduleType: ext.slice(1) } : code
+          }
         },
       },
       jsxRemoveAttributesPlugin(options),

--- a/packages/jsx-remove-attributes/tests/transform.test.ts
+++ b/packages/jsx-remove-attributes/tests/transform.test.ts
@@ -26,7 +26,9 @@ describe('fixtures', () => {
     config.attributes = config.attributes?.map((pattern) => new RegExp(pattern))
 
     it(fixtureName, async () => {
-      const result = await transform(input, config, fullInputPath)
+      const ext = fullInputPath.match(/\.[jt]sx?$/)?.[0] ?? '.jsx'
+      const virtualEntry = `virtual:entry${ext}`
+      const result = await transform(input, config, virtualEntry)
       await expect(result).toMatchFileSnapshot(join(fixturesDir, fixtureName, 'output.js'))
     })
   }
@@ -43,11 +45,9 @@ describe('query-suffixed ids', () => {
 async function transform(
   code: string,
   options: JsxRemoveAttributesOptions,
-  filename = 'virtual:entry.jsx',
+  virtualEntry: string,
 ): Promise<string> {
-  const ext = filename.match(/\.[jt]sx?(?=$|\?)/)?.[0] ?? '.jsx'
-  const virtualEntry = filename.includes('?') ? filename : `virtual:entry${ext}`
-
+  const ext = virtualEntry.match(/\.[jt]sx?$/)?.[0] ?? '.jsx'
   const build = await rolldown({
     input: virtualEntry,
     plugins: [
@@ -59,8 +59,7 @@ async function transform(
         },
         load(id) {
           if (id === virtualEntry) {
-            // query-suffixed ids defeat rolldown's extension-based module type
-            // inference, so set it explicitly (as Vite does in real pipelines)
+            // query-suffixed ids are not inferred by rolldown, so set it explicitly
             return virtualEntry.includes('?') ? { code, moduleType: ext.slice(1) } : code
           }
         },


### PR DESCRIPTION
In Vite pipelines module ids often carry a query (`file.tsx?route-chunk=x`, `?v=hash`, framework-plugin virtual ids). The plugin currently misses those modules in three spots:

1. the transform filter `/\.[jt]sx$/` is end-anchored, so the hook never runs for them — `data-test*` attributes leak into production output (we hit this with React Router route-chunk ids: 27 leaked test ids in a build vs 7 without the query ids);
2. lang detection uses `id.endsWith('.tsx')` on the raw id, degrading to `js` and failing to parse JSX;
3. `meta?.ast` is lazily parsed with the module type rolldown inferred from the raw id, so even with correct lang the cached-AST path throws `Unexpected JSX expression`.

This PR widens the filter to `/\.[jt]sx(?:$|\?)/` (same convention as `@rolldown/plugin-babel`'s default include), derives lang from the query-stripped path, and skips `meta.ast` for query-suffixed ids in favor of an explicit `this.parse` with the right lang.

Added a regression test; the test harness's virtual loader now sets `moduleType` explicitly for query-suffixed entries, since rolldown's extension-based inference can't see through the query either (mirrors what Vite does in real pipelines).

Note: `benchmark/bench/jsx-remove-attributes.test.ts` fails for me on `main` too (unrelated CLI benchmark issue); the transform tests all pass.