### PR TITLE
fix(babel): set `inputSourceMap: false` to avoid combining source map twice

### DIFF
--- a/packages/babel/src/index.test.ts
+++ b/packages/babel/src/index.test.ts
@@ -15,6 +15,35 @@ test('plugin works', async () => {
   expect(result.code).toContain('const result = true')
 })
 
+test('input source maps do not change the generated source map', async () => {
+  const originalCode = '\n\n\n\nexport const answer = 42\n'
+  const inputMap = {
+    version: 3,
+    file: 'foo.js',
+    names: [],
+    sources: ['original.js'],
+    sourcesContent: [originalCode],
+    mappings: 'AAIA',
+  }
+  const inlineMap = Buffer.from(JSON.stringify(inputMap)).toString('base64')
+  const code = 'export const answer = 42\n'
+  const codeWithInputMap = [
+    code,
+    `//# sourceMappingURL=data:application/json;base64,${inlineMap}`,
+  ].join('\n')
+  const options: PluginOptions = { plugins: [() => ({ visitor: {} })] }
+  const outputOptions = { sourcemap: true, sourcemapExcludeSources: true }
+
+  const [withInputMap, withoutInputMap] = await Promise.all([
+    build('foo.js', codeWithInputMap, options, outputOptions),
+    build('foo.js', code, options, outputOptions),
+  ])
+
+  assert(withInputMap.map)
+  assert(withoutInputMap.map)
+  expect(withInputMap.map.toString()).toBe(withoutInputMap.map.toString())
+})
+
 test('presets option applies preset transformations', async () => {
   const myPreset = (): babel.InputOptions => ({
     plugins: [identifierReplaceBabelPlugin('foo', true)],
@@ -792,7 +821,18 @@ async function buildWithVite(
   return chunk
 }
 
-async function build(filename: string, code: string, options: PluginOptions): Promise<OutputChunk> {
+async function build(
+  filename: string,
+  code: string,
+  options: PluginOptions,
+  {
+    sourcemap,
+    sourcemapExcludeSources,
+  }: {
+    sourcemap?: boolean
+    sourcemapExcludeSources?: boolean
+  } = {},
+): Promise<OutputChunk> {
   const bundle = await rolldown({
     input: filename,
     external: [/^react\/jsx-runtime$/],
@@ -817,7 +857,7 @@ async function build(filename: string, code: string, options: PluginOptions): Pr
       babelPlugin(options),
     ],
   })
-  const { output } = await bundle.generate()
+  const { output } = await bundle.generate({ sourcemap, sourcemapExcludeSources })
   assert(output[0].type === 'chunk')
   return output[0]
 }

--- a/packages/babel/src/options.ts
+++ b/packages/babel/src/options.ts
@@ -191,6 +191,8 @@ export function createBabelOptionsConverter(options: ResolvedPluginOptions) {
     const { runtimeVersion: _, ...babelOptions } = options
     return {
       ...babelOptions,
+      // sourcemap collapsing is handled by Rolldown
+      inputSourceMap: false,
       presets: options.presets
         ? filterMap(options.presets, (preset, i) =>
             convertToBabelPresetItem(ctx, preset, presetFilters![i]),

--- a/packages/babel/src/options.ts
+++ b/packages/babel/src/options.ts
@@ -192,6 +192,7 @@ export function createBabelOptionsConverter(options: ResolvedPluginOptions) {
     return {
       ...babelOptions,
       // sourcemap collapsing is handled by Rolldown
+      // @ts-ignore babel v7 types does not allow `false` but it is actually supported
       inputSourceMap: false,
       presets: options.presets
         ? filterMap(options.presets, (preset, i) =>

--- a/packages/babel/src/rolldownPreset.test.ts
+++ b/packages/babel/src/rolldownPreset.test.ts
@@ -34,6 +34,12 @@ function makeRolldownPreset(
 }
 
 describe('createBabelOptionsConverter', () => {
+  test('disables Babel input source map processing', () => {
+    const convert = createBabelOptionsConverter(resolveOptions({}))
+
+    expect(convert(makeCtx()).inputSourceMap).toBe(false)
+  })
+
   test('plain babel preset is always included', () => {
     const convert = createBabelOptionsConverter(resolveOptions({ presets: [presetA] }))
     const result = convert(makeCtx())


### PR DESCRIPTION
Rolldown handles the sourcemap combining. So we should set `inputSourceMap: false`.

fixes https://github.com/rolldown/plugins/issues/126
